### PR TITLE
🔀 fix: tab 공통 컴포넌트 props 받아서 넘길 수 있도록 수정

### DIFF
--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -2,43 +2,20 @@
 
 import { useState } from 'react';
 
-interface TabItem {
+export interface TabItem {
   id: string;
   title: string;
   content: React.ReactNode;
 }
 
-export default function Tab() {  
-  
-  const tabItems: TabItem[] = [
-    {
-      id: 'profile',
-      title: '회원 정보',
-      content: <div className="sub-title">회원 정보</div>,
-    },
-    {
-      id: 'purchase-history',
-      title: '구매 내역',
-      content: <div className="sub-title">구매 내역</div>,
-    },
-    {
-      id: 'wishlist',
-      title: '찜 목록',
-      content: <div className="sub-title">찜 목록</div>,
-    },
-    {
-      id: 'reviews',
-      title: '나의 구매 후기',
-      content: <div className="sub-title">나의 구매 후기</div>,
-    },
-    {
-      id: 'qna',
-      title: '나의 Q&A',
-      content: <div className="sub-title">나의 Q&A</div>,
-    },
-  ];
+// 범용적으로 사용할 수 있도록 props로 tabItems/초기 탭 ID를 받음
+interface TabProps {
+  tabItems: TabItem[];
+  defaultActiveTabId?: string; // 초기 탭 설정용 (선택사항, 미입력 시 )
+}
 
-  const [activeTab, setActiveTab] = useState('profile');
+export default function Tab({ tabItems, defaultActiveTabId }: TabProps) {
+  const [activeTab, setActiveTab] = useState(defaultActiveTabId ?? tabItems[0]?.id);
 
   return (
     <div className="w-full mx-auto">


### PR DESCRIPTION
## PR 유형
- [x] 새로운 기능 추가

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- 기존에 고정되어있던 탭 요소-> props로 받아서 변경할 수 있도록 조정
