### PR TITLE
🔀 feat: 상품 목록 페이지-상세 보기 페이지 연결 완료

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,6 +1,5 @@
-'use client';
-
 import ProductImg from '@/components/ProductImg';
+import Link from 'next/link';
 
 interface ProductCardProps {
   _id: number;
@@ -15,14 +14,15 @@ export default function ProductCard({ _id, imageSrc, title, price }: ProductCard
   const formatPrice = price.toLocaleString();
 
   return (
-    <div className="w-full h-60 md:h-64 rounded">
-      <div className="w-full h-40 md:h-44 rounded-lg relative bg-white">
-        <ProductImg title={title} srcList={[imageSrc]} />
+    <div className="w-full rounded">
+      <div className="w-full aspect-squre rounded-lg relative">
+        <ProductImg title={title} srcList={[imageSrc]} productIid={_id} />
       </div>
-      <h3 className="text-sm sm:text-md text-gray-700 leading-5 line-clamp-2 webkit-line-clamp-2">
-        {_id}.{title}
-      </h3>
-      <p className="font-bold pb-3">{formatPrice}원</p>
+
+      <Link href={`./products/${_id}`}>
+        <span className="text-sm sm:text-md text-gray-700 leading-5 line-clamp-2 webkit-line-clamp-2">{title}</span>
+        <span className="font-bold pb-3">{formatPrice}원</span>
+      </Link>
     </div>
   );
 }

--- a/src/components/ProductImg.tsx
+++ b/src/components/ProductImg.tsx
@@ -9,15 +9,17 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import Link from 'next/link';
 
 interface ProductImgProps {
   title: string;
   // 하나의 이미지라도 배열 형태로 전달받음
   srcList: string[];
   swipe?: boolean;
+  productIid?: number;
 }
 
-function ProductImg({ title, srcList, swipe }: ProductImgProps) {
+function ProductImg({ title, srcList, swipe, productIid }: ProductImgProps) {
   const [liked, setLiked] = useState(false);
 
   const buttonBg = liked ? 'bg-[#FFCC00]' : 'bg-darkgray';
@@ -59,8 +61,16 @@ function ProductImg({ title, srcList, swipe }: ProductImgProps) {
         </div>
       ) : (
         // 제품 목록에 들어갈 고정형 이미지
-        <div className="relative w-full h-full overflow-hidden rounded-lg">
-          <Image src={srcList[0]} alt={title + '이미지'} fill className="object-scale-down" sizes="(min-width: 768px) 100vw, 100vw" />
+        <div className="relative w-full h-full overflow-hidden rounded-lg aspect-square">
+          <Link href={`./products/${productIid}`} className="relative w-full h-full block">
+            <Image
+              src={srcList[0]}
+              alt={title + '이미지'}
+              fill
+              className="object-cover transition-transform duration-300 ease-in-out hover:scale-110 hover:rotate-2"
+              sizes="(min-width: 768px) 100vw, 100vw"
+            />
+          </Link>
           <button
             className={`${buttonBg} rounded-full w-6 h-6 text-white flex justify-center items-center absolute bottom-2.5 right-2.5 cursor-pointer`}
             onClick={() => setLiked(!liked)}


### PR DESCRIPTION
## PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- 상품 목록 페이지에서 상품 클릭하여 상품 상세 페이지로 이동할 수 있도록 Link 연결
- 목록에 표시되는 이미지 비율 조정
- 상품 이미지 hover 효과 추가
 
## 이슈
resolves #74
