### PR TITLE
🔀 fix: 상품 상세 페이지 화면 크기 줄었을 때 이미지 커지는 문제 해결, 변수명 수정

### DIFF
--- a/src/components/ProductImg.tsx
+++ b/src/components/ProductImg.tsx
@@ -28,9 +28,9 @@ function ProductImg({ title, srcList, swipe, productIid }: ProductImgProps) {
     <>
       {swipe ? (
         // 제품 상세에 들어갈 슬라이드형 이미지
-        <div className="relative">
+        <div className="relative aspect-square" style={{ maxWidth: 'calc(100vw - 2rem - 15px)' }}>
           <button
-            className={`${buttonBg} z-10 rounded-full w-6 h-6 text-white flex justify-center items-center absolute bottom-4 right-4 cursor-pointer`}
+            className={`${buttonBg} z-10 rounded-full w-[24px] aspect-square text-white flex justify-center items-center absolute bottom-4 right-4 cursor-pointer`}
             onClick={() => setLiked(!liked)}
             type="button"
             aria-label="찜하기"
@@ -41,13 +41,13 @@ function ProductImg({ title, srcList, swipe, productIid }: ProductImgProps) {
             modules={[Navigation, Pagination]}
             navigation={{ nextEl: '.swiper-button-next', prevEl: '.swiper-button-prev' }}
             pagination={{ clickable: true }}
-            className="relative w-full"
+            className="relative"
           >
             {srcList.map((src, idx) => (
               <SwiperSlide key={idx}>
-                <div className="w-full overflow-hidden rounded-lg aspect-square">
+                <div className="relative w-full overflow-hidden rounded-lg aspect-square max-w-screen">
                   {/* alt값 추가 필요 */}
-                  <Image src={src} alt={title + '이미지'} fill className="object-cover" sizes="100%" />
+                  <Image src={src} alt={title + '이미지'} fill className="object-cover" sizes="(max-width: 640px) 100vw - 2rem - 15px, 100vw" />
                 </div>
               </SwiperSlide>
             ))}
@@ -62,7 +62,7 @@ function ProductImg({ title, srcList, swipe, productIid }: ProductImgProps) {
       ) : (
         // 제품 목록에 들어갈 고정형 이미지
         <div className="relative w-full h-full overflow-hidden rounded-lg aspect-square">
-          <Link href={`./products/${productIid}`} className="relative w-full h-full block">
+          <Link href={`./products/${productIid}`} className="relative block w-full h-full">
             <Image
               src={srcList[0]}
               alt={title + '이미지'}
@@ -72,7 +72,7 @@ function ProductImg({ title, srcList, swipe, productIid }: ProductImgProps) {
             />
           </Link>
           <button
-            className={`${buttonBg} rounded-full w-6 h-6 text-white flex justify-center items-center absolute bottom-2.5 right-2.5 cursor-pointer`}
+            className={`${buttonBg} rounded-full w-[24px] aspect-square text-white flex justify-center items-center absolute bottom-2.5 right-2.5 cursor-pointer`}
             onClick={() => setLiked(!liked)}
             type="button"
             aria-label="찜하기"

--- a/src/components/ProductImg.tsx
+++ b/src/components/ProductImg.tsx
@@ -16,10 +16,10 @@ interface ProductImgProps {
   // 하나의 이미지라도 배열 형태로 전달받음
   srcList: string[];
   swipe?: boolean;
-  productIid?: number;
+  productId?: number;
 }
 
-function ProductImg({ title, srcList, swipe, productIid }: ProductImgProps) {
+function ProductImg({ title, srcList, swipe, productId }: ProductImgProps) {
   const [liked, setLiked] = useState(false);
 
   const buttonBg = liked ? 'bg-[#FFCC00]' : 'bg-darkgray';
@@ -62,7 +62,7 @@ function ProductImg({ title, srcList, swipe, productIid }: ProductImgProps) {
       ) : (
         // 제품 목록에 들어갈 고정형 이미지
         <div className="relative w-full h-full overflow-hidden rounded-lg aspect-square">
-          <Link href={`./products/${productIid}`} className="relative block w-full h-full">
+          <Link href={`./products/${productId}`} className="relative block w-full h-full">
             <Image
               src={srcList[0]}
               alt={title + '이미지'}


### PR DESCRIPTION
## PR 유형

- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

- 상품 상세 이미지 컴포넌트 화면 크기 줄었을 때 이미지 커지는 문제 해결(바깥 div에 정확한 maxWidth 추가)
- productId 변수명 오타 수정
- 찜하기 버튼 크기 고정

## 이슈

resolves #144 
