### PR TITLE
🔀 feat: 상품 상세 페이지 구매하기 데이터 담기 기능 구현

### DIFF
--- a/src/app/products/[id]/ProductPostForm.tsx
+++ b/src/app/products/[id]/ProductPostForm.tsx
@@ -18,8 +18,25 @@ function ProductPostForm({ productData }: { productData: ApiRes<ProductInfo> }) 
   const [cartFailModal, setCartFailModal] = useState(false);
   const [purchaseFailModal, setPurchaseFailModal] = useState(false);
 
+  // 구매하기 데이터 담기
+  const checkout = () => {
+    if (!productData.ok || !option) {
+      setPurchaseFailModal(true);
+    } else {
+      const checkoutData = {
+        _id: productData.item._id,
+        quantity: quantity,
+        color: option,
+      };
+
+      sessionStorage.setItem('checkoutData', JSON.stringify(checkoutData));
+      router.push(`/checkout?from=info&product_id=${checkoutData._id}`);
+    }
+  };
+
+  // 장바구니에 담기
   const [state, formAction, isPending] = useActionState(addToCart, null);
-  console.log(state);
+
   useEffect(() => {
     if (state?.ok === 1) {
       setCartSuccessModal(true);
@@ -59,7 +76,9 @@ function ProductPostForm({ productData }: { productData: ApiRes<ProductInfo> }) 
             <Button outlined size="full" submit>
               장바구니
             </Button>
-            <Button size="full">구매하기</Button>
+            <Button size="full" onClick={checkout}>
+              구매하기
+            </Button>
           </div>
         </div>
       </form>
@@ -85,7 +104,13 @@ function ProductPostForm({ productData }: { productData: ApiRes<ProductInfo> }) 
       />
 
       {/* 구매 실패 모달 */}
-      {/* <Modal isOpen={} handleClose={} handleConfirm={} /> */}
+      <Modal
+        isOpen={purchaseFailModal}
+        handleClose={() => setPurchaseFailModal(false)}
+        handleConfirm={() => setPurchaseFailModal(false)}
+        description={option ? '구매에 실패했습니다.' : '옵션을 선택해주세요.'}
+        hideCancelButton
+      />
     </div>
   );
 }


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

- 상품 상세 페이지 구매하기 데이터 담기 기능 구현
  - 구매하기 버튼 클릭 시 상품 id, 수량, 색상이 Session storage에 담김
  - 결제하기 페이지로 이동 (params로 from=info, product_id 전달)
  - 상품 데이터가 없거나 옵션 선택되지 않았을 시 구매 실패 모달 띄움

## 이슈

resolves #100 
