### PR TITLE
🔀 fix: 캐러셀 상세 페이지 링크 연결, 축 정보 추가

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -14,72 +14,81 @@ const slideData = [
     src: '/carousel_images/carousel-image1.webp',
     position: 'justify-end items-end', // 우하
     title: 'KICK75',
+    switch: '',
     description: 'Craft Your Perfect Keyboard',
-    link: '/',
+    link: '/products/18',
     buttonStyle: 'bg-black text-background',
   },
   {
     src: '/carousel_images/carousel-image2.webp',
     position: 'justify-center items-center', // 중앙
     title: 'AIR96 V2',
+    switch: '청축',
     description: 'Craft Your Perfect Keyboard',
-    link: '/',
+    link: '/products/7',
     buttonStyle: 'bg-background text-black',
   },
   {
     src: '/carousel_images/carousel-image3.webp',
     position: 'justify-start items-end', // 우상
     title: 'AIR75 V2',
+    switch: '적축',
     description: 'Craft Your Perfect Keyboard',
-    link: '/',
+    link: '/products/6',
     buttonStyle: 'bg-black text-background',
   },
   {
     src: '/carousel_images/carousel-image4.webp',
     position: 'justify-center items-start', // 좌중
     title: 'BH65 FULL ALUMINUM',
+    switch: 'Jade PRO',
     description: 'Craft Your Perfect Keyboard',
-    link: '/',
+    link: '/products/',
     buttonStyle: 'bg-background text-black',
   },
-  {
-    src: '/carousel_images/carousel-image5.webp',
-    position: 'justify-center items-center', // 중앙
-    title: 'Halo65 HE',
-    description: 'Craft Your Perfect Keyboard',
-    link: '/',
-    buttonStyle: 'bg-black text-background',
-  },
-  {
-    src: '/carousel_images/carousel-image6.webp',
-    position: 'justify-end items-start', // 좌하
-    title: 'AIR75 HE',
-    description: 'Craft Your Perfect Keyboard',
-    link: '/',
-    buttonStyle: 'bg-background text-black',
-  },
+  // {
+  //   src: '/carousel_images/carousel-image5.webp',
+  //   position: 'justify-center items-center', // 중앙
+  //   title: 'Halo65 HE',
+  //   switch: '',
+  //   description: 'Craft Your Perfect Keyboard',
+  //   link: '/',
+  //   buttonStyle: 'bg-black text-background',
+  // },
+  // {
+  //   src: '/carousel_images/carousel-image6.webp',
+  //   position: 'justify-end items-start', // 좌하
+  //   title: 'AIR75 HE',
+  //   switch: '',
+  //   description: 'Craft Your Perfect Keyboard',
+  //   link: '/',
+  //   buttonStyle: 'bg-background text-black',
+  // },
   {
     src: '/carousel_images/carousel-image10.webp',
     position: 'justify-center items-center', // 중앙
     title: 'Halo75 V2',
+    switch: '레몬축',
     description: 'Craft Your Perfect Keyboard',
-    link: '/',
+    link: '/products/14',
     buttonStyle: 'bg-black text-background',
   },
   {
     src: '/carousel_images/carousel-image12.webp',
     position: 'justify-center items-end', // 우중
     title: 'AIR60 V2',
+    switch: '갈축',
     description: 'Craft Your Perfect Keyboard',
-    link: '/',
+    link: '/products/2',
     buttonStyle: 'bg-black text-background',
   },
   {
     src: '/carousel_images/carousel-image8.webp',
     position: 'justify-center items-center', // 중앙
     title: 'Field75 HE',
+    switch: 'Magnetic Jade',
     description: 'Craft Your Perfect Keyboard',
-    link: '/',
+    link: '/products/12',
     buttonStyle: 'bg-background text-black',
   },
 ];
@@ -107,7 +116,10 @@ export default function Carousel() {
                                 ${slide.position}`}
                   >
                     <h1 className="sr-only">Hero section title</h1>
-                    <h2 className="title text-background text-4xl">{slide.title}</h2>
+                    <div className="flex flex-row items-baseline gap-1">
+                      <h2 className="title text-background text-4xl">{slide.title}</h2>
+                      <h2 className="title text-background text-lg">{slide.switch}</h2>
+                    </div>
                     <p className="contents text-background">{slide.description}</p>
                     <Link className={`${slide.buttonStyle} px-4 py-2 md:px-8 md:py-3 mt-5 rounded cursor-pointer w-fit`} href={slide.link}>
                       상세 페이지로 이동


### PR DESCRIPTION
## PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- 캐러셀 버튼에 상세 페이지 링크 연결
- 제품 축 정보 표시 추가
- 제품 정보 없는 캐러셀 이미지 2건 주석 처리

## 이슈
resolves #159
