### PR TITLE
🔀 fix: 구매완료 후 장바구니 비우기 로직 변경

### DIFF
--- a/src/app/checkout/CheckOutForm.tsx
+++ b/src/app/checkout/CheckOutForm.tsx
@@ -29,6 +29,7 @@ interface DeliveryInfo {
 
 // 상품 정보 타입
 interface ProductInfo {
+  cartId?: number;
   id: number;
   name: string;
   image: string;
@@ -39,7 +40,6 @@ interface ProductInfo {
 
 // 주문 정보 타입
 interface OrderInfo {
-  cartId?: number;
   products: ProductInfo[];
   subtotal: number; // 상품 총액
   shippingFee: number; // 배송비
@@ -97,7 +97,6 @@ export default function CheckOutForm({ token, orderInfo }: CheckoutPageProps) {
 
   // 세션스토리지 데이터를 반영한 주문 정보 상태
   const [currentOrderInfo, setCurrentOrderInfo] = useState<OrderInfo>(orderInfo);
-
   // 유저 배송지 정보 (props가 없을 때 사용)
   const { user, hasHydrated } = useAuthStore();
 
@@ -143,7 +142,6 @@ export default function CheckOutForm({ token, orderInfo }: CheckoutPageProps) {
 
           // 업데이트된 주문 정보로 상태 변경
           setCurrentOrderInfo({
-            cartId: orderInfo.cartId,
             products: updatedProducts,
             subtotal,
             shippingFee,
@@ -425,14 +423,16 @@ export default function CheckOutForm({ token, orderInfo }: CheckoutPageProps) {
   //장바구니 비우기
   const clearCart = async () => {
     try {
-      const cartId = currentOrderInfo.cartId; // 첫 번째 상품의 cartId 사용
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/carts/${cartId}`, {
+      const carts = currentOrderInfo.products.map(product => product.cartId);
+      console.log('장바구니 비우기 요청:', carts);
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/carts`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
           'Client-Id': process.env.NEXT_PUBLIC_API_CLIENT_ID!,
           Authorization: `Bearer ${token}`,
         },
+        body: JSON.stringify({ carts }),
       });
 
       if (res.ok) {

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -22,9 +22,9 @@ export default async function CheckoutPage({ searchParams }: CheckoutPageProps) 
     orderData =
       cartRes.ok === 1
         ? {
-            cartId: cartRes.item?.[0]?._id,
             products:
               cartRes.item?.map(item => ({
+                cartId: item._id,
                 id: item.product_id,
                 name: item.product.name,
                 image: `${item.product.image.path}` || '',

--- a/src/data/functions/carts.ts
+++ b/src/data/functions/carts.ts
@@ -31,7 +31,6 @@ export default async function getCartList(token: string): ApiResPromise<CartItem
     });
 
     const result = await response.json();
-
     // API 응답이 실패인 경우 그대로 반환
     if (result.ok !== 1) {
       return { ok: 0, message: result.message || '장바구니 조회 실패' };


### PR DESCRIPTION
## PR 유형

- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

이전 장바구니 비우는 로직이 장바구니 아이템 하나만 삭제되고 있었음

장바구니 아이템 아이디를 배열로 만들어 한번에 지우게 변경


## 이슈

resolves #214 
