### PR TITLE
🔀 fix: 캐러셀 이미지 크기 조정, 상품 목록 순서 조정 토글 반응형 디자인 적용

### DIFF
--- a/src/app/products/components/SortToggle.tsx
+++ b/src/app/products/components/SortToggle.tsx
@@ -7,12 +7,12 @@ const options: sortType[] = ['최신순', '가나다순', '가격 낮은순', '�
 
 export default function SortToggle({ selected, setSelected }: { selected: sortType; setSelected: (option: sortType) => void }) {
   return (
-    <div className="flex gap-2 mb-3 flex-wrap">
+    <div className="w-full flex gap-2 mb-3 justify-between sm:justify-start">
       {options.map(option => (
-        <label key={option} className="cursor-pointer">
+        <label key={option} className="flex-1 sm:flex-none cursor-pointer">
           <input type="radio" name="sort" value={option} checked={selected === option} onChange={() => setSelected(option)} className="sr-only" />
           <div
-            className={`px-4 py-1.5 rounded text-[14px] transition
+            className={`px-1 sm:px-4 py-1.5 rounded text-center text-sm sm:text-xs transition whitespace-nowrap
               ${selected === option ? 'bg-primary text-white' : 'bg-accent text-gray-600'}`}
             tabIndex={0}
             onKeyDown={e => {

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -108,7 +108,14 @@ export default function Carousel() {
         {slideData.map((slide, i) => (
           <SwiperSlide key={i}>
             <div className="relative w-full h-[20rem] sm:h-[25rem] md:h-[30rem] ">
-              <Image src={slide.src} alt={slide.title} className="w-full h-full object-cover object-center rounded-xl" fill sizes="100vw" priority />
+              <Image
+                src={slide.src}
+                alt={slide.title}
+                className="w-full h-full object-cover object-center rounded-xl"
+                fill
+                sizes="(min-width: 768px) 768px,100vw"
+                priority
+              />
               <div className="absolute inset-0 bg-black/25 rounded-xl">
                 <div className="absolute inset-0 flex justify-center items-center px-6">
                   <div


### PR DESCRIPTION
## PR 유형
- [x] 버그 수정

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- 캐러셀 fill 관련 warning 제거를 위해 이미지 크기 조정
- 상품 목록 순서 조정 토글 반응형 디자인 적용
